### PR TITLE
Refactor tokenise complexity

### DIFF
--- a/src/lib/parser/Char.test.ts
+++ b/src/lib/parser/Char.test.ts
@@ -33,7 +33,7 @@ describe('Char tests', () => {
       expect(c.toLowerCase()).toStrictEqual('a');
     });
 
-    it('isALpha is true for letters', () => {
+    it('isAlpha is true for letters', () => {
       const c = new Char('a');
       expect(c.isAlpha()).toStrictEqual(true);
     });
@@ -51,6 +51,18 @@ describe('Char tests', () => {
     it('isNumeric is true for digits', () => {
       const c = new Char('1');
       expect(c.isNumeric()).toStrictEqual(true);
+    });
+
+    it('isOneOf is false when the char value is not in the provided array', () => {
+      const array = ['a', 'b'];
+      const c = new Char('c');
+      expect(c.isOneOf(array)).toStrictEqual(false);
+    });
+
+    it('isOneOf is true when the char value is in the provided array', () => {
+      const array = ['a', 'b', 'c'];
+      const c = new Char('c');
+      expect(c.isOneOf(array)).toStrictEqual(true);
     });
   });
 });

--- a/src/lib/parser/Char.ts
+++ b/src/lib/parser/Char.ts
@@ -58,6 +58,10 @@ export class Char {
   equals(value: string): boolean {
     return this.char === value;
   }
+
+  isOneOf(valueArray: string[]): boolean {
+    return valueArray.some(value => this.equals(value));
+  }
 }
 
 

--- a/src/lib/parser/Tokeniser.test.ts
+++ b/src/lib/parser/Tokeniser.test.ts
@@ -1,5 +1,5 @@
 import { Token, TokenType } from "../domain/Token";
-import { Tokeniser, getMatchedBracketFromTokenType } from "./Tokeniser";
+import { Tokeniser, getMatchedBracketFromTokenType, getTokenTypeFromBracket } from "./Tokeniser";
 
 const getTokens = (input: string) => {
   const tokeniser = new Tokeniser(input);
@@ -9,42 +9,72 @@ const getTokens = (input: string) => {
 
 describe('Tokeniser tests', () => {
 
-  describe('Matching brackets', () => {
-    it('matches `)` to TokenType.L_PAREN', () => {
+  describe('Matching TokenTypes to opposing brackets', () => {
+    it('matches TokenType.L_PAREN to `)`', () => {
       expect(getMatchedBracketFromTokenType(TokenType.L_PAREN)).toStrictEqual(')');
     });
 
-    it('matches `(` to TokenType.R_PAREN', () => {
+    it('matches TokenType.R_PAREN to `(`', () => {
       expect(getMatchedBracketFromTokenType(TokenType.R_PAREN)).toStrictEqual('(');
     });
 
-    it('matches `]` to TokenType.L_BRACKET', () => {
+    it('matches TokenType.L_BRACKET to `]`', () => {
       expect(getMatchedBracketFromTokenType(TokenType.L_BRACKET)).toStrictEqual(']');
     });
 
-    it('matches `[` to TokenType.R_BRACKET', () => {
+    it('matches TokenType.R_BRACKET to `[`', () => {
       expect(getMatchedBracketFromTokenType(TokenType.R_BRACKET)).toStrictEqual('[');
     });
 
-    it('matches `}` to TokenType.L_BRACE', () => {
+    it('matches TokenType.L_BRACE to `}`', () => {
       expect(getMatchedBracketFromTokenType(TokenType.L_BRACE)).toStrictEqual('}');
     });
 
-    it('matches `{` to TokenType.R_BRACE', () => {
+    it('matches TokenType.R_BRACE to `{`', () => {
       expect(getMatchedBracketFromTokenType(TokenType.R_BRACE)).toStrictEqual('{');
     });
 
-    it('matches `/` to TokenType.FORWARD_SLASH', () => {
+    it('matches TokenType.FORWARD_SLASH to `/`', () => {
       expect(getMatchedBracketFromTokenType(TokenType.FORWARD_SLASH)).toStrictEqual('/');
     });
 
-    it('matches `\\` to TokenType.BACKWARD_SLASH', () => {
+    it('matches TokenType.BACKWARD_SLASH to `\\`', () => {
       expect(getMatchedBracketFromTokenType(TokenType.BACKWARD_SLASH)).toStrictEqual('\\');
     });
 
     it('throws error if passed a non-bracket type', () => {
       expect(() => getMatchedBracketFromTokenType(TokenType.SEMI)).toThrow('Unknown bracket type! Could not match.');
     });
+  });
+
+  describe('Matching strings that are brackets to TokenTypes', () => {
+      it('matches `(` to TokenType.L_PAREN', () => {
+        expect(getTokenTypeFromBracket('(')).toStrictEqual(TokenType.L_PAREN);
+      });
+      
+      it('matches `)` to TokenType.R_PAREN', () => {
+        expect(getTokenTypeFromBracket(')')).toStrictEqual(TokenType.R_PAREN);
+      });
+
+      it('matches `{` to TokenType.L_BRACE', () => {
+        expect(getTokenTypeFromBracket('{')).toStrictEqual(TokenType.L_BRACE);
+      });
+      
+      it('matches `}` to TokenType.R_BRACE', () => {
+        expect(getTokenTypeFromBracket('}')).toStrictEqual(TokenType.R_BRACE);
+      });
+
+      it('matches `[` to TokenType.L_BRACKET', () => {
+        expect(getTokenTypeFromBracket('[')).toStrictEqual(TokenType.L_BRACKET);
+      });
+      
+      it('matches `]` to TokenType.R_BRACKET', () => {
+        expect(getTokenTypeFromBracket(']')).toStrictEqual(TokenType.R_BRACKET);
+      });
+
+      it('throws error if passed a non-bracket string', () => {
+        expect(() => getTokenTypeFromBracket('x')).toThrow('Unknown bracket type! Could not match.');
+      });
   });
 
   describe('Tokeniser Peek and Consume', () => {

--- a/src/lib/parser/Tokeniser.ts
+++ b/src/lib/parser/Tokeniser.ts
@@ -1,7 +1,6 @@
 import { Char } from "./Char";
 import { Token, TokenType } from "../domain/Token";
 import { Buffer } from './Buffer';
-import * as log from "../../Log";
 
 export class Tokeniser {
 
@@ -92,58 +91,6 @@ export class Tokeniser {
     this.tokens.push({ type: TokenType.STRING, value: this.buffer.toString(), pos, len: this.i - pos });
   }
 
-  #handleForwardSlash() {
-    if (this.peek(1).equals('/')) {
-      this.consume();
-      this.consume();
-      this.#handleComment();
-    } else {
-      this.tokens.push({ type: TokenType.FORWARD_SLASH, pos: this.i, len: 1 });
-      this.consume();
-    }
-  }
-
-  #handleBackSlash() {
-    this.tokens.push({ type: TokenType.BACKWARD_SLASH, pos: this.i, len: 1 });
-    this.consume();
-  }
-
-  #handleEquals() {
-    const pos = this.i;
-    this.consume();
-    if (!this.peek().equals('>')) {
-      this.throwError("Unexpected assignment! Expected '>'");
-    }
-    this.consume();
-    this.tokens.push({ type: TokenType.ARROW, pos, len: 2 });
-  }
-
-  #handleSemi() {
-    this.tokens.push({ type: TokenType.SEMI, pos: this.i, len: 1 });
-    this.consume();
-  }
-
-  #handleLParen() {
-    this.tokens.push({ type: TokenType.L_PAREN, pos: this.i, len: 1 });
-    this.consume();
-  }
-
-  #handleRParen() {
-    this.tokens.push({ type: TokenType.R_PAREN, pos: this.i, len: 1 });
-    this.consume();
-  }
-
-  #handleComment() {
-    while (this.peek().isWhiteSpace()) {
-      this.consume();
-    }
-    const pos = this.i;
-    while (!this.peek().isNewLine() && !this.peek().isEoF()) {
-      this.buffer.push(this.consume());
-    }
-    this.tokens.push({ type: TokenType.COMMENT, value: this.buffer.toString(), pos, len: this.i - pos });
-  }
-
   #handleAlphaNumeric() {
     const pos = this.i;
     this.buffer.push(this.consume());
@@ -186,11 +133,54 @@ export class Tokeniser {
     this.tokens.push({ type: TokenType.STRING, value: this.buffer.toString(), pos, len: this.buffer.length() });
   }
 
+  #handleEquals() {
+    const pos = this.i;
+    this.consume();
+    if (!this.peek().equals('>')) {
+      this.throwError("Unexpected assignment! Expected '>'");
+    }
+    this.consume();
+    this.tokens.push({ type: TokenType.ARROW, pos, len: 2 });
+  }
+
+  #handleSemi() {
+    this.tokens.push({ type: TokenType.SEMI, pos: this.i, len: 1 });
+    this.consume();
+  }
+
+  #handleForwardSlash() {
+    if (this.peek(1).equals('/')) {
+      this.consume();
+      this.consume();
+      this.#handleComment();
+    } else {
+      this.tokens.push({ type: TokenType.FORWARD_SLASH, pos: this.i, len: 1 });
+      this.consume();
+    }
+  }
+
+  #handleBackSlash() {
+    this.tokens.push({ type: TokenType.BACKWARD_SLASH, pos: this.i, len: 1 });
+    this.consume();
+  }
+
   #handleBracket() {
     const char = this.consume();
     const type = getTokenTypeFromBracket(char.toString());
     this.tokens.push({ type, pos: this.i - 1, len: 1 });
   }
+
+  #handleComment() {
+    while (this.peek().isWhiteSpace()) {
+      this.consume();
+    }
+    const pos = this.i;
+    while (!this.peek().isNewLine() && !this.peek().isEoF()) {
+      this.buffer.push(this.consume());
+    }
+    this.tokens.push({ type: TokenType.COMMENT, value: this.buffer.toString(), pos, len: this.i - pos });
+  }
+
 
   peek(at: number = 0): Char {
     const c = this.src[this.i + at];

--- a/src/lib/parser/Tokeniser.ts
+++ b/src/lib/parser/Tokeniser.ts
@@ -37,21 +37,22 @@ export class Tokeniser {
   tokenise() {
     this.reset();
     while (!this.peek().isEoF()) {
-      if (this.peek().isQuote()) {
+      const nextChar = this.peek();
+      if (nextChar.isQuote()) {
         this.#handleQuote();
-      } else if (this.peek().isBacktick()) {
+      } else if (nextChar.isBacktick()) {
         this.#handleBacktick();
-      } else if (this.peek().isAlphaNumeric()) {
+      } else if (nextChar.isAlphaNumeric()) {
         this.#handleAlphaNumeric();
-      } else if (this.peek().equals('=')) {
+      } else if (nextChar.equals('=')) {
         this.#handleEquals();
-      } else if (this.peek().equals(';')) {
+      } else if (nextChar.equals(';')) {
         this.#handleSemi();
-      } else if (this.peek().equals('/')) {
+      } else if (nextChar.equals('/')) {
         this.#handleForwardSlash();
-      } else if (this.peek().equals('\\')) {
+      } else if (nextChar.equals('\\')) {
         this.#handleBackSlash();
-      } else if (this.peek().isOneOf(['(', ')', '{', '}', '[', ']'])) {
+      } else if (nextChar.isOneOf(['(', ')', '{', '}', '[', ']'])) {
         this.#handleBracket();
       } else {
         // Next Char is whitespace, newline, or unrecognised.

--- a/src/lib/parser/Tokeniser.ts
+++ b/src/lib/parser/Tokeniser.ts
@@ -44,10 +44,6 @@ export class Tokeniser {
         this.#handleBacktick();
       } else if (this.peek().isAlphaNumeric()) {
         this.#handleAlphaNumeric();
-      } else if (this.peek().isWhiteSpace()) {
-        this.consume();
-      } else if (this.peek().isNewLine()) {
-        this.consume();
       } else if (this.peek().equals('=')) {
         this.#handleEquals();
       } else if (this.peek().equals(';')) {
@@ -59,6 +55,7 @@ export class Tokeniser {
       } else if (this.peek().isOneOf(['(', ')', '{', '}', '[', ']'])) {
         this.#handleBracket();
       } else {
+        // Next Char is whitespace, newline, or unrecognised.
         this.consume();
       }
       this.buffer.clear();

--- a/src/lib/parser/Tokeniser.ts
+++ b/src/lib/parser/Tokeniser.ts
@@ -56,22 +56,8 @@ export class Tokeniser {
         this.#handleForwardSlash();
       } else if (this.peek().equals('\\')) {
         this.#handleBackSlash();
-      } else if (this.peek().equals('(')) {
-        this.#handleLParen();
-      } else if (this.peek().equals(')')) {
-        this.#handleRParen();
-      } else if (this.peek().equals('[')) {
-        this.tokens.push({ type: TokenType.L_BRACKET, pos: this.i, len: 1 });
-        this.consume();
-      } else if (this.peek().equals(']')) {
-        this.tokens.push({ type: TokenType.R_BRACKET, pos: this.i, len: 1 });
-        this.consume();
-      } else if (this.peek().equals('{')) {
-        this.tokens.push({ type: TokenType.L_BRACE, pos: this.i, len: 1 });
-        this.consume();
-      } else if (this.peek().equals('}')) {
-        this.tokens.push({ type: TokenType.R_BRACE, pos: this.i, len: 1 });
-        this.consume();
+      } else if (this.peek().isOneOf(['(', ')', '{', '}', '[', ']'])) {
+        this.#handleBracket();
       } else {
         this.consume();
       }
@@ -203,6 +189,12 @@ export class Tokeniser {
     this.tokens.push({ type: TokenType.STRING, value: this.buffer.toString(), pos, len: this.buffer.length() });
   }
 
+  #handleBracket() {
+    const char = this.consume();
+    const type = getTokenTypeFromBracket(char.toString());
+    this.tokens.push({ type, pos: this.i - 1, len: 1 });
+  }
+
   peek(at: number = 0): Char {
     const c = this.src[this.i + at];
     if (c === undefined) {
@@ -257,6 +249,25 @@ export const getMatchedBracketFromTokenType = (type: TokenType) => {
       return '/';
     case TokenType.BACKWARD_SLASH:
       return '\\';
+    default:
+      throw new Error('Unknown bracket type! Could not match.')
+  }
+}
+
+export const getTokenTypeFromBracket = (bracket: string) => {
+  switch (bracket) {
+    case '{':
+      return TokenType.L_BRACE;
+    case '}':
+      return TokenType.R_BRACE;
+    case '(':
+      return TokenType.L_PAREN;
+    case ')':
+      return TokenType.R_PAREN;
+    case '[':
+      return TokenType.L_BRACKET;
+    case ']':
+      return TokenType.R_BRACKET;
     default:
       throw new Error('Unknown bracket type! Could not match.')
   }


### PR DESCRIPTION
`Tokeniser.tokenise()` had a cognitive complexity of 45 or some nonsense. Refactored until it was much simpler to understand.

Adds `Char.isOneOf(array: string[])` to quickly check if a char matches any of a given array of strings