### PR TITLE
NodeParser abstraction

### DIFF
--- a/src/lib/parser/LinkGenerator.test.ts
+++ b/src/lib/parser/LinkGenerator.test.ts
@@ -1,0 +1,162 @@
+import { LinkGenerator } from "./LinkGenerator";
+import { NodeParser } from "./NodeParser";
+import { Tokeniser } from "./Tokeniser";
+import { resetId } from "./Node";
+
+
+interface GeneratorOptionsArgs {
+  trueLabel?: string;
+  falseLabel?: string;
+  skipGeneration?: boolean;
+}
+
+const getGenerator = (input: string, options: GeneratorOptionsArgs = {}) => {
+  const tokeniser = new Tokeniser(input);
+  tokeniser.tokenise();
+  const parser = new NodeParser(tokeniser);
+  parser.parse();
+  const linkGenerator = new LinkGenerator(parser.root, {
+    trueLabel: options.trueLabel ?? 'True',
+    falseLabel: options.falseLabel ?? 'False',
+  });
+  if (!options.skipGeneration) {
+    linkGenerator.start();
+  }
+  return linkGenerator;
+}
+
+describe('LinkGenerator tests', () => {
+
+  beforeEach(() => {
+    resetId();
+  });
+
+  describe('LinkGenerator.addLabel()', () => {
+    it('adds a basic label using numbers', () => {
+      const generator = getGenerator('');
+      generator.addLabel('1', '2');
+      expect(generator.text).toStrictEqual('  1-->2\n');
+    });
+
+    it('adds a basic label using strings', () => {
+      const generator = getGenerator('');
+      generator.addLabel('80', '82');
+      expect(generator.text).toStrictEqual('  80-->82\n');
+    });
+
+    it('adds a label with text', () => {
+      const generator = getGenerator('');
+      generator.addLabel(5, 6, 'some text');
+      expect(generator.text).toStrictEqual('  5-->|some text|6\n');
+    });
+
+    it('will add multiple labels', () => {
+      const generator = getGenerator('');
+      generator.addLabel(5, 6);
+      generator.addLabel(6, 7);
+      expect(generator.text).toStrictEqual('  5-->6\n  6-->7\n');
+    });
+
+    it('will not add a duplicate label', () => {
+      const generator = getGenerator('');
+      generator.addLabel(5, 6);
+      generator.addLabel(5, 6);
+      expect(generator.text).toStrictEqual('  5-->6\n');
+    });
+  });
+
+  it('initialises the text to be empty', () => {
+    const generator = getGenerator('one; two', { skipGeneration: true, });
+    expect(generator.text).toStrictEqual('');
+  });
+
+  it('empty input causes no links to be generated', () => {
+    const generator = getGenerator('');
+    expect(generator.text).toStrictEqual('');
+  });
+
+  it('creates a link between two nodes', () => {
+    const generator = getGenerator('one; two;');
+    expect(generator.text).toStrictEqual('  1-->2\n');
+  });
+
+  it('does not link to a return node', () => {
+    const generator = getGenerator('one; return;');
+    expect(generator.text).toStrictEqual('');
+  });
+
+  describe('Conditions', () => {
+    it('will link to both sides of an if/else block', () => {
+      const generator = getGenerator('if (true) { one; } else { two; }');
+      const expected = '  1-->|True|4\n  1-->|False|5\n';
+      expect(generator.text).toStrictEqual(expected);
+    });
+
+    it('will join both sides back up to a following node', () => {
+      const generator = getGenerator('if (true) { one; } else { two; } three;');
+      const expected = '  1-->|True|4\n  1-->|False|5\n  4 & 5-->6\n';
+      expect(generator.text).toStrictEqual(expected);
+    });
+
+    it('will respect a return statement in an if block', () => {
+      const generator = getGenerator('if (true) { one; return; } else { two; } three;');
+      const expected = '  1-->|True|4\n  1-->|False|6\n  6-->7\n';
+      expect(generator.text).toStrictEqual(expected);
+    });
+
+    it('will respect a return statement in an else block', () => {
+      const generator = getGenerator('if (true) { one; } else { two; return; } three;');
+      const expected = '  1-->|True|4\n  1-->|False|5\n  4-->7\n';
+      expect(generator.text).toStrictEqual(expected);
+    });
+
+    it('will terminate both sides if both contain return statements', () => {
+      const generator = getGenerator('if (true) { one; return; } else { two; return; } three;');
+      const expected = '  1-->|True|4\n  1-->|False|6\n';
+      expect(generator.text).toStrictEqual(expected);
+    });
+
+    it('will terminate both sides if both contain return statements and start a new graph section', () => {
+      const generator = getGenerator('if (true) { one; return; } else { two; return; } three; four;');
+      const expected = '  1-->|True|4\n  1-->|False|6\n  8-->9\n';
+      expect(generator.text).toStrictEqual(expected);
+    });
+
+    it('handles an if block without an else', () => {
+      const generator = getGenerator('if (true) { one; }');
+      const expected = '  1-->|True|4\n';
+      expect(generator.text).toStrictEqual(expected);
+    });
+
+    it('handles an if block without an else that continues on', () => {
+      const generator = getGenerator('if (true) { one; } two;');
+      const expected = '  1-->|True|4\n  4-->5\n  1-->|False|5\n';
+      expect(generator.text).toStrictEqual(expected);
+    });
+
+    it('uses a custom value for true', () => {
+      const generator = getGenerator('if (true) { one; } two;', {
+        trueLabel: 'yes',
+      });
+      const expected = '  1-->|yes|4\n  4-->5\n  1-->|False|5\n';
+      expect(generator.text).toStrictEqual(expected);
+    });
+
+    it('uses a custom value for false', () => {
+      const generator = getGenerator('if (true) { one; } two;', {
+        falseLabel: 'no',
+      });
+      const expected = '  1-->|True|4\n  4-->5\n  1-->|no|5\n';
+      expect(generator.text).toStrictEqual(expected);
+    });
+
+    it('uses a custom value for true and false', () => {
+      const generator = getGenerator('if (true) { one; } two;', {
+        trueLabel: 'yes',
+        falseLabel: 'no',
+      });
+      const expected = '  1-->|yes|4\n  4-->5\n  1-->|no|5\n';
+      expect(generator.text).toStrictEqual(expected);
+    });
+  });
+});

--- a/src/lib/parser/LinkGenerator.test.ts
+++ b/src/lib/parser/LinkGenerator.test.ts
@@ -134,6 +134,12 @@ describe('LinkGenerator tests', () => {
       expect(generator.text).toStrictEqual(expected);
     });
 
+    it('handles an if block that returns', () => {
+      const generator = getGenerator('if ( true) { one; return; } two; three;');
+      const expected = '  1-->|True|4\n  1-->|False|6\n  6-->7\n';
+      expect(generator.text).toStrictEqual(expected);
+    });
+
     it('uses a custom value for true', () => {
       const generator = getGenerator('if (true) { one; } two;', {
         trueLabel: 'yes',

--- a/src/lib/parser/LinkGenerator.ts
+++ b/src/lib/parser/LinkGenerator.ts
@@ -1,0 +1,78 @@
+import { AbstractNode, ConditionNode, ExpressionNode, ProgramNode, ReturnNode } from "./Node";
+
+interface LinkGeneratorOptions {
+  trueLabel: string;
+  falseLabel: string;
+}
+
+export class LinkGenerator {
+  root: ProgramNode;
+  options: LinkGeneratorOptions;
+
+  #text: string;
+
+  constructor(root: ProgramNode, options: LinkGeneratorOptions) {
+    this.root = root;
+    this.options = {
+      trueLabel: options.trueLabel,
+      falseLabel: options.falseLabel,
+    };
+    this.#text = '';
+  }
+
+  get text() {
+    return this.#text;
+  }
+
+  start() {
+    this.#generate(this.root);
+  }
+
+  #generate(root: AbstractNode): number[] {
+    for (const [i, node] of root.instructions.entries()) {
+      if (node instanceof ReturnNode) {
+        continue;
+      }
+      let previous: AbstractNode | undefined;
+      if (i > 0) {
+        previous = root.instructions[i - 1];
+      }
+      if (previous instanceof ExpressionNode) {
+        this.addLabel(previous.id, node.id);
+      } else if (previous instanceof ConditionNode) {
+        const previousIds = previous.getTerminalIds().join(' & ');
+        this.addLabel(previousIds, node.id);
+      }
+      if (node instanceof ConditionNode) {
+        this.#handleConditionNode(i, root, node);
+      }
+    }
+    return [];
+  }
+
+  #handleConditionNode(i: number, root: AbstractNode, node: ConditionNode) {
+    const firstIf = node.ifBlock.instructions[0];
+    this.addLabel(node.id, firstIf.id, this.options.trueLabel);
+    this.#generate(node.ifBlock);
+    const firstElse = node.elseBlock.instructions[0];
+    if (firstElse) {
+      this.addLabel(node.id, firstElse.id, this.options.falseLabel);
+      this.#generate(node.elseBlock);
+    } else {
+      const nextNode = root.instructions[i + 1];
+      if (nextNode) {
+        this.addLabel(node.ifBlock.getLastInstruction().id, nextNode.id);
+        this.addLabel(node.id, nextNode.id, this.options.falseLabel);
+      }
+    }
+  }
+
+  addLabel(from: string | number, to: string | number, label?: string) {
+    if (from === undefined || from === '' || to === undefined || to === '') return;
+    const tag = label === undefined ? '' : `|${label}|`;
+    const arrow = `  ${from}-->${tag}${to}\n`;
+    if (!this.text.includes(arrow)) {
+      this.#text += arrow;
+    }
+  }
+}

--- a/src/lib/parser/LinkGenerator.ts
+++ b/src/lib/parser/LinkGenerator.ts
@@ -61,7 +61,10 @@ export class LinkGenerator {
     } else {
       const nextNode = root.instructions[i + 1];
       if (nextNode) {
-        this.addLabel(node.ifBlock.getLastInstruction().id, nextNode.id);
+        const lastNodeInIfBlock = node.ifBlock.getLastInstruction();
+        if (!(lastNodeInIfBlock instanceof ReturnNode)) {
+          this.addLabel(lastNodeInIfBlock.id, nextNode.id);
+        }
         this.addLabel(node.id, nextNode.id, this.options.falseLabel);
       }
     }

--- a/src/lib/parser/NodeParser.test.ts
+++ b/src/lib/parser/NodeParser.test.ts
@@ -52,7 +52,7 @@ describe('NodeParser tests', () => {
     });
 
     it('should initialise arrows to empty string', () => {
-      expect(parser.arrows).toStrictEqual('');
+      expect(parser.links).toStrictEqual('');
     });
 
     it('should initialise classDefs to empty string', () => {


### PR DESCRIPTION
- reduces cognitive complexity of `NodeParser.#parse` method.
  - pulls out nested blocks to new class methods
- Adds `LinkGenerator` class to replace methods in `NodeParser`
  -  Handles adding mermaid arrows between various nodes
  - Fixes bug where a `return` statement on both sides of an if else would not terminate with expected behaviour
    - Fixes #12 