### PR TITLE
Allow strings beginning with reserved keywords

### DIFF
--- a/src/lib/parser/Char.ts
+++ b/src/lib/parser/Char.ts
@@ -1,3 +1,5 @@
+export const EOF_CHAR: string = '•';
+
 export class Char {
   readonly char: string;
   constructor(char: string) {
@@ -20,7 +22,7 @@ export class Char {
   }
 
   isEoF(): boolean {
-    return this.equals('•');
+    return this.equals(EOF_CHAR);
   }
 
   isAlpha(): boolean {

--- a/src/lib/parser/Tokeniser.test.ts
+++ b/src/lib/parser/Tokeniser.test.ts
@@ -121,6 +121,36 @@ describe('Tokeniser tests', () => {
 
   describe('Tokenising', () => {
 
+    describe('Reserved Keywords', () => {
+
+      it('can start a string with if without problems', () => {
+        const actual = getTokens('iffiness;');
+        const expected: Token[] = [
+          { type: TokenType.STRING, value: 'iffiness', pos: { pos: 0, len: 8, col: 1, ln: 1 } },
+          { type: TokenType.SEMI, pos: { pos: 8, len: 1, col: 9, ln: 1 } },
+        ]
+        expect(actual).toStrictEqual(expected);
+      });
+
+      it('can start a string with else without problems', () => {
+        const actual = getTokens('elsewhere;');
+        const expected: Token[] = [
+          { type: TokenType.STRING, value: 'elsewhere', pos: { pos: 0, len: 9, col: 1, ln: 1 } },
+          { type: TokenType.SEMI, pos: { pos: 9, len: 1, col: 10, ln: 1 } },
+        ]
+        expect(actual).toStrictEqual(expected);
+      });
+
+      it('can start a string with return without problems', () => {
+        const actual = getTokens('returning;');
+        const expected: Token[] = [
+          { type: TokenType.STRING, value: 'returning', pos: { pos: 0, len: 9, col: 1, ln: 1 } },
+          { type: TokenType.SEMI, pos: { pos: 9, len: 1, col: 10, ln: 1 } },
+        ]
+        expect(actual).toStrictEqual(expected);
+      });
+    });
+
     it('parses a semicolon', () => {
       const input = ';';
       const actual = getTokens(input);

--- a/src/lib/parser/Tokeniser.test.ts
+++ b/src/lib/parser/Tokeniser.test.ts
@@ -117,6 +117,28 @@ describe('Tokeniser tests', () => {
       t.consume();
       expect(() => t.consume()).toThrow('Cannot consume, end of file.');
     });
+
+    it('matches the next char', () => {
+      expect(t.nextIsOneOf('0')).toStrictEqual(true);
+      expect(t.nextIsOneOf('p')).toStrictEqual(false);
+      expect(t.nextIsOneOf('a', 'b', '0')).toStrictEqual(true);
+      t.consume();
+      expect(t.nextIsOneOf('0', '1', '2')).toStrictEqual(true);
+      expect(t.nextIsOneOf('0')).toStrictEqual(false);
+      expect(t.nextIsOneOf('1')).toStrictEqual(true);
+    });
+
+    it('fails to match next when no arguments are given', () => {
+      expect(t.nextIsOneOf()).toStrictEqual(false);
+    });
+
+    it('matches the next char if it is EOF', () => {
+      t.consume();
+      t.consume();
+      t.consume();
+      expect(t.nextIsOneOf()).toStrictEqual(true);
+      expect(t.nextIsOneOf('a', 'b', 'c')).toStrictEqual(true);
+    });
   });
 
   describe('Tokenising', () => {

--- a/src/lib/parser/Tokeniser.test.ts
+++ b/src/lib/parser/Tokeniser.test.ts
@@ -171,6 +171,21 @@ describe('Tokeniser tests', () => {
         ]
         expect(actual).toStrictEqual(expected);
       });
+
+      it('can use a reserved keyword if it is in a string', () => {
+        const actual = getTokens(`'else';\n'if';\n'return';\n'while';`);
+        const expected: Token[] = [
+          { type: TokenType.STRING, value: 'else', pos: { pos: 0, len: 6, col: 1, ln: 1 } },
+          { type: TokenType.SEMI, pos: { pos: 6, len: 1, col: 7, ln: 1 } },
+          { type: TokenType.STRING, value: 'if', pos: { pos: 8, len: 4, col: 1, ln: 2 } },
+          { type: TokenType.SEMI, pos: { pos: 12, len: 1, col: 5, ln: 2 } },
+          { type: TokenType.STRING, value: 'return', pos: { pos: 14, len: 8, col: 1, ln: 3 } },
+          { type: TokenType.SEMI, pos: { pos: 22, len: 1, col: 9, ln: 3 } },
+          { type: TokenType.STRING, value: 'while', pos: { pos: 24, len: 7, col: 1, ln: 4 } },
+          { type: TokenType.SEMI, pos: { pos: 31, len: 1, col: 8, ln: 4 } },
+        ]
+        expect(actual).toStrictEqual(expected);
+      });
     });
 
     it('parses a semicolon', () => {

--- a/src/lib/parser/Tokeniser.ts
+++ b/src/lib/parser/Tokeniser.ts
@@ -1,4 +1,4 @@
-import { Char } from "./Char";
+import { Char, EOF_CHAR } from "./Char";
 import { CharPos, Token, TokenType } from "../domain/Token";
 import { Buffer } from './Buffer';
 
@@ -110,23 +110,23 @@ export class Tokeniser {
       !(latestTokenIsOpeningBracket && this.peek().equals(matched))
     ) {
       this.buffer.push(this.consume());
-      if (this.buffer.equals('return')) {
+      if (this.buffer.equals('return') && this.nextIsOneOf(';', ' ')) {
         this.tokens.push({ type: TokenType.RETURN, pos: this.#getCharPos(pos, 6) });
         return;
       }
-      if (this.buffer.equals('if')) {
+      if (this.buffer.equals('if') && this.nextIsOneOf(' ', '(')) {
         this.tokens.push({ type: TokenType.IF, pos: this.#getCharPos(pos, 2) });
         return;
       }
-      if (this.buffer.equals('while')) {
+      if (this.buffer.equals('while') && this.nextIsOneOf(' ', '(')) {
         this.tokens.push({ type: TokenType.WHILE, pos: this.#getCharPos(pos, 5) });
         return;
       }
-      if (this.buffer.equals('else')) {
+      if (this.buffer.equals('else') && this.nextIsOneOf(' ', '{')) {
         this.tokens.push({ type: TokenType.ELSE, pos: this.#getCharPos(pos, 4) });
         return;
       }
-      if (this.buffer.equals('switch')) {
+      if (this.buffer.equals('switch') && this.nextIsOneOf(' ', '(')) {
         this.tokens.push({ type: TokenType.SWITCH, pos: this.#getCharPos(pos, 6) });
         return;
       }
@@ -212,6 +212,11 @@ export class Tokeniser {
       return new Char('•');
     }
     return new Char(c);
+  }
+
+  nextIsOneOf(...charValues: string[]) {
+    const next = this.peek();
+    return [EOF_CHAR, ...charValues].includes(next.char);
   }
 
   consume(): Char {


### PR DESCRIPTION
Closes #8 
Adds additional checks before determining if a word is a reserved keyword or not. 
Allows a word that starts with a reserved keyword to be treated as a regular string.

Still allows wrapping in a string to start a node with a reserved keyword.